### PR TITLE
Fix Windows bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3459,8 +3459,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "issue-parser": {
       "version": "4.0.0",
@@ -9489,6 +9488,14 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
+    "unwrap-npm-cmd": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unwrap-npm-cmd/-/unwrap-npm-cmd-1.1.0.tgz",
+      "integrity": "sha512-SThF6OeCucl31SMs/Gy5Q9HoS+DC6yYcH/dX+EH3v8ZgNtnzt7KV+7n9bqzCQqpsN+AVKssBymSNONAFi+1mXw==",
+      "requires": {
+        "which": "^1.3.1"
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -9566,7 +9573,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "ansi-bold": "^0.1.1",
     "global-dirs": "^1.0.0",
     "import-from": "^3.0.0",
-    "log-symbols": "^3.0.0"
+    "log-symbols": "^3.0.0",
+    "unwrap-npm-cmd": "^1.1.0"
   },
   "engines": {
     "node": ">=8.0.0",

--- a/src/create-yo.js
+++ b/src/create-yo.js
@@ -7,8 +7,23 @@ const globalDirs = require('global-dirs');
 const importFrom = require('import-from');
 const symbols = require('log-symbols');
 const bold = require('ansi-bold');
+const fs = require('fs');
 
 const PREFIX = 'generator-';
+
+function getNpxCliPathWindows() {
+  // On Windows globalDirs.npm.packages can resolve to
+  // "%APPDATA%\Roaming\npm\node_modules"
+  // when the location of libnpx is actually
+  // "%ProgramFiles%\nodejs\node_modules\npm\node_modules"
+
+  // Find the location of the npx-cli.js script.
+  // ex: "C:\Program Files\nodejs\node_modules\npm\bin\npx-cli.js"
+  let npxCli = require('unwrap-npm-cmd')('npx', {jsOnly: true});
+
+  // Strip the quotes around the string.
+  return npxCli.replace(/^"|"$/g, '');
+}
 
 const npx = (() => {
   try {
@@ -19,21 +34,19 @@ const npx = (() => {
     }
   }
 
-  // On Windows globalDirs.npm.packages can resolve to
-  // "%APPDATA%\Roaming\npm\node_modules"
-  // when the location of libnpx is actually
-  // "%ProgramFiles%\nodejs\node_modules\npm\node_modules"
-  const unwrapNpmCmd = require('unwrap-npm-cmd');
-
-  // Find the location of the npx-cli.js script.
-  // ex: "C:\Program Files\nodejs\node_modules\npm\bin\npx-cli.js"
-  let npxCli = unwrapNpmCmd('npx', {jsOnly: true});
-
-  // Strip the quotes around the string.
-  npxCli = npxCli.replace(/^"|"$/g, '');
-
+  const npxCli = getNpxCliPathWindows();
   return importFrom(npxCli, 'libnpx');
 })();
+
+function getNpmPath() {
+  let npmPath = path.join(globalDirs.npm.binaries, 'npm');
+  if (process.platform === 'win32' && !fs.existsSync(npmPath)) {
+    let npmCli = require('unwrap-npm-cmd')('npm', {jsOnly: true});
+    // Strip the quotes around the string.
+    npmPath = npmCli.replace(/^"|"$/g, '');
+  }
+  return npmPath;
+}
 
 /**
  * Invokes `npx` with `--package yo --package generator-generatorName -- yo generatorName`
@@ -43,10 +56,7 @@ const npx = (() => {
  * @param {string} [npmPath] - Absolute path to `npm-cli.js`
  * @returns {Promise<void>} When finished
  */
-async function create(
-  argv = process.argv.slice(),
-  npmPath = path.join(globalDirs.npm.binaries, 'npm')
-) {
+async function create(argv = process.argv.slice(), npmPath = getNpmPath()) {
   if (argv.length < 3) {
     throw new Error(
       `specify a generator to run via ${bold(


### PR DESCRIPTION
Fixes https://github.com/boneskull/create-yo/issues/4

> The problem is that on a regular Windows Node.js installation, `globalDirs.npm.packages` points to:
> `C:\Users\dev\AppData\Roaming\npm\node_modules`.
> 
> Yet `libnpx` is located in the Node.js installation directory at:
> `C:\Program Files\nodejs\node_modules\npm\node_modules\libnpx`
> 
> So this line files `importFrom(path.join(globalDirs.npm.packages, 'npm'), 'libnpx')`.
> 
> Not sure what a clean fix for this looks like.. since `global-dirs` is correct in providing the directory for user installed global packages. Tested with `globalDirs.npm.binaries` which also points to the user dir `C:\Users\dev\AppData\Roaming\npm`.

I'm opening as a draft PR since this is a pretty hacky solution and I'm not thrilled with it, however, it does fix the issue on Windows.

The original bug reporter stated a similar issue was happening on a linux install. I suspect the problem is the same -- depending on how the Node.js installation is packaged, the `global-dirs` lib makes no sense in this context since this tool is targeting core Node.js components rather than user installed global modules. 


### Alternative solution (?)

If the core node.js `node_modules` directory is always located at the location that the `npm` or `npx` shell commands evaluate to, then a more elegant and cross platform solution could be using the [`which`](https://www.npmjs.com/package/which) package to evaluate the location of `npm` and use that for locating `libnpx`. 

Thoughts?